### PR TITLE
修复span换行样式无法识别的问题

### DIFF
--- a/content.js
+++ b/content.js
@@ -99,7 +99,7 @@ const siyuanConvertBlobToBase64 = (blob) => new Promise((resolve, reject) => {
 function isIgnoredElement(element) {
     // 递归查找父元素直到找到 pre、code、span、math 或 math相关标签
     while (element) {
-		let tagName = element.tagName.toLowerCase();
+        let tagName = element.tagName.toLowerCase();
         const className = element.className.toLowerCase();
         if (tagName === 'math' ||
             className.includes('math') || className.includes('mathjax') || className.includes('latex') ||
@@ -109,11 +109,13 @@ function isIgnoredElement(element) {
         }
 
         element = element.parentElement; // 移动到父元素
-        if(!element)
+        if(!element) {
             break;
+        }
+
         tagName = element.tagName.toLowerCase();
 
-		// 如果父元素是 pre、code、span、math 或与数学相关的类名
+        // 如果父元素是 pre、code、span、math 或与数学相关的类名
         if (tagName === 'pre' || tagName === 'code' || tagName === 'span') {
             return true;
         } else if (tagName === 'div' || tagName === 'p') {
@@ -142,11 +144,11 @@ function siyuanSpansAddBr(tempElement) {
             (style.whiteSpace.trim().toLowerCase() === 'normal' || style.whiteSpace.trim().toLowerCase() === 'pre-wrap') &&
             (style.wordWrap.trim().toLowerCase() === 'break-word' || style.overflowWrap.trim().toLowerCase() === 'break-word' || style.wordBreak.trim().toLowerCase() === 'break-word')
         ) {
-			// 检查父元素是否是 pre、code 或 span
-			if (isIgnoredElement(span)) {
-				console.log('Skipping span due to parent being pre, code or span.');
-				return; // 如果父元素是 pre、code 或 span 或者数学公式，跳过该 span
-			}
+            // 检查父元素是否是 pre、code 或 span
+            if (isIgnoredElement(span)) {
+                console.log('Skipping span due to parent being pre, code or span.');
+                return; // 如果父元素是 pre、code 或 span 或者数学公式，跳过该 span
+            }
 
             const br = document.createElement('br'); // 修正为从 document 创建元素
             br.setAttribute('data-added-by-siyuan', 'true');

--- a/content.js
+++ b/content.js
@@ -102,14 +102,14 @@ function isIgnoredElement(element) {
 		const tagName = element.tagName.toLowerCase();
         const className = element.className.toLowerCase();
         if (tagName === 'math' ||
-            className.includes('math') || className.includes('mathjax') || className.includes('latex') || 
-            className.includes('katex') || className.includes('mjx') || className.includes('mathml') || 
+            className.includes('math') || className.includes('mathjax') || className.includes('latex') ||
+            className.includes('katex') || className.includes('mjx') || className.includes('mathml') ||
             className.includes('equation') || className.includes('formula')) {
             return true;
         }
-        
+
         element = element.parentElement; // 移动到父元素
-        
+
 		// 如果父元素是 pre、code、span、math 或与数学相关的类名
         if (tagName === 'pre' || tagName === 'code' || tagName === 'span') {
             return true;

--- a/content.js
+++ b/content.js
@@ -94,29 +94,50 @@ const siyuanConvertBlobToBase64 = (blob) => new Promise((resolve, reject) => {
     reader.readAsDataURL(blob)
 })
 
-
 // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
 // 处理会换行的span后添加 <br>，让kernel能识别到换行
 function siyuanSpansAddBr(tempElement) {
     const spans = tempElement.querySelectorAll('span');
+    if (!spans || spans.length === 0) {
+        console.log('No span elements found.');
+        return;
+    }
+
+    // 用于存储符合条件的 span 元素
+    const matchedSpans = [];
+
     spans.forEach((span) => {
         const style = window.getComputedStyle(span);
         if (
             (style.whiteSpace.trim().toLowerCase() === 'normal' || style.whiteSpace.trim().toLowerCase() === 'pre-wrap') &&
             (style.wordWrap.trim().toLowerCase() === 'break-word' || style.overflowWrap.trim().toLowerCase() === 'break-word' || style.wordBreak.trim().toLowerCase() === 'break-word')
         ) {
-            const br = tempElement.createElement('br');
+            const br = document.createElement('br'); // 修正为从 document 创建元素
             br.setAttribute('data-added-by-siyuan', 'true');
             span.parentNode.insertBefore(br, span.nextSibling);
+
+            // 添加到符合条件的数组中
+            matchedSpans.push(span);
         }
     });
+
+    if (matchedSpans.length > 0) {
+        console.log(`Added <br> for ${matchedSpans.length} span elements.`);
+        console.log('Matched span elements:', matchedSpans);
+    } else {
+        console.log('No span elements matched the criteria.');
+    }
 };
 
 // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
 // 移除由 span_add_br 添加的 <br>，还原原有样式
 function siyuanSpansDelBr(tempElement) {
     const brs = tempElement.querySelectorAll('br[data-added-by-siyuan="true"]');
+    if (!brs || brs.length === 0) {
+        return;
+    }
     brs.forEach((br) => br.parentNode.removeChild(br));
+    console.log(`siyuanSpansDelBr Removed ${brs.length} <br> elements.`);
 };
 
 const siyuanSendUpload = async (tempElement, tabId, srcUrl, type, article, href) => {

--- a/content.js
+++ b/content.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             if ('copy2Clipboard' === request.func) {
-                copyToClipboard(request.data)
+                await copyToClipboard(request.data)
                 return
             }
 
@@ -25,9 +25,16 @@ document.addEventListener('DOMContentLoaded', function () {
                 siyuanSendUpload(tempElement, request.tabId, request.srcUrl, "part")
             }
         })
-    const copyToClipboard = (textToCopy) => {
+    const copyToClipboard = async (textToCopy) => {
+		// 修复无焦点的未捕获异常：https://github.com/siyuan-note/siyuan/issues/13208
+		await new Promise(resolve => requestAnimationFrame(resolve));
+
         if (navigator.clipboard && window.isSecureContext) {
-            return navigator.clipboard.writeText(textToCopy)
+			try {
+				return await navigator.clipboard.writeText(textToCopy);
+			} catch (error) {
+				//console.warn('Failed to copy text: ', error);
+			}
         }
 
         let textArea = document.createElement('textarea')
@@ -91,7 +98,6 @@ const siyuanConvertBlobToBase64 = (blob) => new Promise((resolve, reject) => {
 // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
 // 处理会换行的span后添加 <br>，让kernel能识别到换行
 function siyuanSpansAddBr(tempElement) {
-    console.log('siyuanSpansAddBr');
     const spans = tempElement.querySelectorAll('span');
     spans.forEach((span) => {
         const style = window.getComputedStyle(span);
@@ -109,7 +115,6 @@ function siyuanSpansAddBr(tempElement) {
 // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
 // 移除由 span_add_br 添加的 <br>，还原原有样式
 function siyuanSpansDelBr(tempElement) {
-    console.log('siyuanSpansDelBr');
     const brs = tempElement.querySelectorAll('br[data-added-by-siyuan="true"]');
     brs.forEach((br) => br.parentNode.removeChild(br));
 };

--- a/content.js
+++ b/content.js
@@ -26,15 +26,15 @@ document.addEventListener('DOMContentLoaded', function () {
             }
         })
     const copyToClipboard = async (textToCopy) => {
-		// 修复无焦点的未捕获异常：https://github.com/siyuan-note/siyuan/issues/13208
-		await new Promise(resolve => requestAnimationFrame(resolve));
+        // 修复无焦点的未捕获异常：https://github.com/siyuan-note/siyuan/issues/13208
+        await new Promise(resolve => requestAnimationFrame(resolve));
 
         if (navigator.clipboard && window.isSecureContext) {
-			try {
-				return await navigator.clipboard.writeText(textToCopy);
-			} catch (error) {
-				//console.warn('Failed to copy text: ', error);
-			}
+            try {
+                return await navigator.clipboard.writeText(textToCopy);
+            } catch (error) {
+                //console.warn('Failed to copy text: ', error);
+            }
         }
 
         let textArea = document.createElement('textarea')

--- a/content.js
+++ b/content.js
@@ -109,6 +109,8 @@ function isIgnoredElement(element) {
         }
 
         element = element.parentElement; // 移动到父元素
+        if(!element)
+            break;
         tagName = element.tagName.toLowerCase();
 
 		// 如果父元素是 pre、code、span、math 或与数学相关的类名

--- a/content.js
+++ b/content.js
@@ -99,7 +99,7 @@ const siyuanConvertBlobToBase64 = (blob) => new Promise((resolve, reject) => {
 function isIgnoredElement(element) {
     // 递归查找父元素直到找到 pre、code、span、math 或 math相关标签
     while (element) {
-		const tagName = element.tagName.toLowerCase();
+		let tagName = element.tagName.toLowerCase();
         const className = element.className.toLowerCase();
         if (tagName === 'math' ||
             className.includes('math') || className.includes('mathjax') || className.includes('latex') ||
@@ -109,6 +109,7 @@ function isIgnoredElement(element) {
         }
 
         element = element.parentElement; // 移动到父元素
+        tagName = element.tagName.toLowerCase();
 
 		// 如果父元素是 pre、code、span、math 或与数学相关的类名
         if (tagName === 'pre' || tagName === 'code' || tagName === 'span') {
@@ -161,7 +162,6 @@ function siyuanSpansAddBr(tempElement) {
         console.log('No span elements matched the criteria.');
     }
 };
-
 
 // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
 // 移除由 span_add_br 添加的 <br>，还原原有样式

--- a/content.js
+++ b/content.js
@@ -87,6 +87,33 @@ const siyuanConvertBlobToBase64 = (blob) => new Promise((resolve, reject) => {
     reader.readAsDataURL(blob)
 })
 
+
+// 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
+// 处理会换行的span后添加 <br>，让kernel能识别到换行
+function siyuanSpansAddBr(tempElement) {
+    console.log('siyuanSpansAddBr');
+    const spans = tempElement.querySelectorAll('span');
+    spans.forEach((span) => {
+        const style = window.getComputedStyle(span);
+        if (
+            (style.whiteSpace.trim().toLowerCase() === 'normal' || style.whiteSpace.trim().toLowerCase() === 'pre-wrap') &&
+            (style.wordWrap.trim().toLowerCase() === 'break-word' || style.overflowWrap.trim().toLowerCase() === 'break-word' || style.wordBreak.trim().toLowerCase() === 'break-word')
+        ) {
+            const br = tempElement.createElement('br');
+            br.setAttribute('data-added-by-siyuan', 'true');
+            span.parentNode.insertBefore(br, span.nextSibling);
+        }
+    });
+};
+
+// 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
+// 移除由 span_add_br 添加的 <br>，还原原有样式
+function siyuanSpansDelBr(tempElement) {
+    console.log('siyuanSpansDelBr');
+    const brs = tempElement.querySelectorAll('br[data-added-by-siyuan="true"]');
+    brs.forEach((br) => br.parentNode.removeChild(br));
+};
+
 const siyuanSendUpload = async (tempElement, tabId, srcUrl, type, article, href) => {
     chrome.storage.sync.get({
         ip: 'http://127.0.0.1:6806',

--- a/popup.js
+++ b/popup.js
@@ -201,8 +201,10 @@ const siyuanGetReadability = (tabId) => {
         // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
         // 处理会换行的span后添加 <br>，让kernel能识别到换行
         siyuanSpansAddBr(document)
+        const clonedDoc = document.cloneNode(true);
+        siyuanSpansDelBr(document)
 
-        const article = new Readability(document.cloneNode(true), {
+        const article = new Readability(clonedDoc, {
             keepClasses: true,
             charThreshold: 16,
             debug: true
@@ -212,10 +214,6 @@ const siyuanGetReadability = (tabId) => {
         // console.log(article)
         siyuanSendUpload(tempElement, tabId, undefined, "article", article, window.location.href)
         siyuanClearTip()
-
-        // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
-        // 移除由 span_add_br 添加的 <br>，还原原有样式
-        siyuanSpansDelBr(document)
     } catch (e) {
         console.error(e)
         siyuanShowTip(e.message, 7 * 1000)

--- a/popup.js
+++ b/popup.js
@@ -198,6 +198,10 @@ const siyuanGetReadability = (tabId) => {
             item.classList.add("hljs-cmt")
         })
 
+        // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
+        // 处理会换行的span后添加 <br>，让kernel能识别到换行
+        siyuanSpansAddBr(document)
+
         const article = new Readability(document.cloneNode(true), {
             keepClasses: true,
             charThreshold: 16,
@@ -208,6 +212,10 @@ const siyuanGetReadability = (tabId) => {
         // console.log(article)
         siyuanSendUpload(tempElement, tabId, undefined, "article", article, window.location.href)
         siyuanClearTip()
+
+        // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
+        // 移除由 span_add_br 添加的 <br>，还原原有样式
+        siyuanSpansDelBr(document)
     } catch (e) {
         console.error(e)
         siyuanShowTip(e.message, 7 * 1000)


### PR DESCRIPTION
修复span换行样式无法识别的问题
https://github.com/siyuan-note/siyuan/issues/13195

如issues 13195沟通，对于span样式换行的文本，在span标签末尾追加br字段，剪报流程完成以后再移除掉，还原网页