### PR TITLE
:art: Improve HTML clipping https://github.com/siyuan-note/siyuan/issues/13306

### DIFF
--- a/options.html
+++ b/options.html
@@ -408,6 +408,25 @@
         <div style="flex: 1">Download assets</div>
         <input class="b3-switch" id="assets" checked type="checkbox">
     </label>
+    <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
+        <div class="b3-label" style="flex: 1">Show experimental features</div>
+        <input class="b3-switch" id="exp" type="checkbox">
+    </label>
+    <div id="expGroup" style="display: none;">
+      <div class="b3-label" style="font-size: 14px; color: red;">*:Experimental features may be unstable. If there is a problem with clipping, consider switching it.</div>
+      <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
+          <div style="flex: 1">Detect span text newlines*</div>
+          <input class="b3-switch" id="expSpan" checked type="checkbox">
+      </label>
+      <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
+          <div style="flex: 1">Detect bold style*</div>
+          <input class="b3-switch" id="expBold" type="checkbox">
+      </label>
+      <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
+          <div style="flex: 1">Detect italic style*</div>
+          <input class="b3-switch" id="expItalic" type="checkbox">
+      </label>
+    </div>
     <div class="fn__hr"></div>
     <div class="fn__hr"></div>
     <button class="b3-button" id="send">Send to SiYuan</button>

--- a/popup.js
+++ b/popup.js
@@ -6,6 +6,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const parentDocElement = document.getElementById('parentDoc')
     const tagsElement = document.getElementById('tags')
     const assetsElement = document.getElementById('assets')
+    const expElement = document.getElementById('exp')
+    const expGroupElement = document.getElementById('expGroup')
+    const expSpanElement = document.getElementById('expSpan')
+    const expBoldElement = document.getElementById('expBold')
+    const expItalicElement = document.getElementById('expItalic')
 
     ipElement.addEventListener('change', () => {
         let ip = ipElement.value;
@@ -63,6 +68,28 @@ document.addEventListener('DOMContentLoaded', () => {
             assets: assetsElement.checked,
         })
     })
+    expSpanElement.addEventListener('change', () => {
+        chrome.storage.sync.set({
+            expSpan: expSpanElement.checked,
+        })
+    })
+    expBoldElement.addEventListener('change', () => {
+        chrome.storage.sync.set({
+            expBold: expBoldElement.checked,
+        })
+    })
+    expItalicElement.addEventListener('change', () => {
+        chrome.storage.sync.set({
+            expItalic: expItalicElement.checked,
+        })
+    })
+    expElement.addEventListener('change', function () {
+        if (expElement.checked) {
+            expGroupElement.style.display = 'block';
+        } else {
+            expGroupElement.style.display = 'none';
+        }
+    });
 
     const eyeElement = document.querySelector('.b3-icon')
     eyeElement.addEventListener('click', () => {
@@ -98,6 +125,9 @@ document.addEventListener('DOMContentLoaded', () => {
         parentHPath: '',
         tags: '',
         assets: true,
+        expSpan: true,
+        expBold: false,
+        expItalic: false,
     }, function (items) {
         ipElement.value = items.ip || 'http://127.0.0.1:6806'
         tokenElement.value = items.token || ''
@@ -108,6 +138,9 @@ document.addEventListener('DOMContentLoaded', () => {
         parentDocElement.setAttribute("data-parenthpath", items.parentHPath)
         tagsElement.value = items.tags || ''
         assetsElement.checked = items.assets
+        expSpanElement.checked = items.expSpan
+        expBoldElement.checked = items.expBold
+        expItalicElement.checked = items.expItalic
         updateSearch()
     })
 })
@@ -182,7 +215,7 @@ const escapeHtml = (unsafe) => {
         .replace(/'/g, "&#039;");
 }
 
-const siyuanGetReadability = (tabId) => {
+const siyuanGetReadability = async (tabId) => {
     try {
         siyuanShowTip('Clipping, please wait a moment...', 60 * 1000)
     } catch (e) {
@@ -198,11 +231,8 @@ const siyuanGetReadability = (tabId) => {
             item.classList.add("hljs-cmt")
         })
 
-        // 网页换行用span样式word-break的特殊处理 https://github.com/siyuan-note/siyuan/issues/13195
-        // 处理会换行的span后添加 <br>，让kernel能识别到换行
-        siyuanSpansAddBr(document)
-        const clonedDoc = document.cloneNode(true);
-        siyuanSpansDelBr(document)
+        // 重构并合并Readability前处理 https://github.com/siyuan-note/siyuan/issues/13306
+        const clonedDoc = await siyuanGetCloneNode(document);
 
         const article = new Readability(clonedDoc, {
             keepClasses: true,


### PR DESCRIPTION
:art: Improve HTML clipping https://github.com/siyuan-note/siyuan/issues/13306
+) Add bold and italic style detection into experimental features
*) Move span newlines detection into experimental features
*) Change funtion siyuanGetReadability to async funtion with popup.js
主要新增了粗体和斜体检测（默认关闭），加上之前的span换行检测（默认开启），统统移动到实验性功能里
chrome.storage.sync也增加了对应的3个布尔类型配置

siyuanGetReadability 改成async函数，然后重构了下cloneNode部分代码在这里前后做处理，提取出克隆节点后逐个和还原。
最终效果图我在实验性功能后边加了个星号*
![image](https://github.com/user-attachments/assets/f56113c3-d298-46b9-8d3c-eb1289eb8a55)
