### PR TITLE
:art: Add i18n Support

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "سييوان (SiYuan)"
+  },
+  "extension_description": {
+    "message": "قص الويب لسييوان."
+  },
+  "copy_to_siyuan": {
+    "message": "نسخ إلى سييوان"
+  },
+  
+  "show_tip": {
+    "message": "إظهار النصائح"
+  },
+  "siyuan_url": {
+    "message": "رابط سييوان"
+  },
+  "api_token": {
+    "message": "رمز API"
+  },
+  "save_path": {
+    "message": "مسار الحفظ"
+  },
+  "save_path_placeholder": {
+    "message": "أدخل الكلمة المفتاحية ثم اضغط Enter للبحث"
+  },
+  "tags": {
+    "message": "العلامات"
+  },
+  "tags_placeholder": {
+    "message": "استخدم الفواصل لفصل العلامات"
+  },
+  "assets": {
+    "message": "تحميل الأصول"
+  },
+  "exp": {
+    "message": "عرض الميزات التجريبية"
+  },
+  "exp_tips": {
+    "message": "*: الميزات التجريبية قد تكون غير مستقرة. إذا كانت هناك مشكلة في القص، حاول التبديل بينها."
+  },
+  "exp_span": {
+    "message": "اكتشاف فواصل النص في span*"
+  },
+  "exp_bold": {
+    "message": "اكتشاف النصوص العريضة*"
+  },
+  "exp_italic": {
+    "message": "اكتشاف النصوص المائلة*"
+  },
+  "language": {
+    "message": "اللغة*"
+  },
+  "send": {
+    "message": "إرسال إلى سييوان"
+  },
+
+  "tip_first_time": {
+    "message": "بعد تثبيت الإضافة لأول مرة، يُرجى تحديث الصفحة قبل استخدامها"
+  },
+  "tip_clipping": {
+    "message": "جارٍ القص، يرجى الانتظار..."
+  },
+  "tip_clip_img": {
+    "message": "جارٍ قص الصورة"
+  },
+  "tip_clip_ok": {
+    "message": "تم القص بنجاح"
+  },
+  "tip_token_miss": {
+    "message": "يرجى تكوين رمز API قبل قص المحتوى"
+  },
+  "tip_token_invalid": {
+    "message": "رمز API غير صالح"
+  },
+  "tip_save_path_miss": {
+    "message": "يرجى اختيار مسار الحفظ قبل قص المحتوى"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "يرجى تشغيل سييوان والتأكد من الاتصال بالشبكة قبل المحاولة مرة أخرى"
+  }
+}

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Web-Clipping für SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "Nach SiYuan kopieren"
+  },
+  
+  "show_tip": {
+    "message": "Tipp anzeigen"
+  },
+  "siyuan_url": {
+    "message": "SiYuan URL"
+  },
+  "api_token": {
+    "message": "API-Token"
+  },
+  "save_path": {
+    "message": "Speicherort"
+  },
+  "save_path_placeholder": {
+    "message": "Geben Sie das Schlüsselwort ein und drücken Sie Enter, um zu suchen"
+  },
+  "tags": {
+    "message": "Tags"
+  },
+  "tags_placeholder": {
+    "message": "Verwenden Sie Kommas, um mehrere Tags zu trennen"
+  },
+  "assets": {
+    "message": "Assets herunterladen"
+  },
+  "exp": {
+    "message": "Experimentelle Funktionen anzeigen"
+  },
+  "exp_tips": {
+    "message": "*: Experimentelle Funktionen können instabil sein. Wenn es ein Problem mit dem Clipping gibt, versuchen Sie, es zu wechseln."
+  },
+  "exp_span": {
+    "message": "Textumbruch in span erkennen*"
+  },
+  "exp_bold": {
+    "message": "Fettdruck-Stil erkennen*"
+  },
+  "exp_italic": {
+    "message": "Kursiv-Stil erkennen*"
+  },
+  "language": {
+    "message": "Sprache*"
+  },
+  "send": {
+    "message": "Nach SiYuan senden"
+  },
+
+  "tip_first_time": {
+    "message": "Bitte laden Sie die Seite nach der ersten Installation der SiYuan-Erweiterung neu, bevor Sie sie verwenden"
+  },
+  "tip_clipping": {
+    "message": "Clipping, bitte warten..."
+  },
+  "tip_clip_img": {
+    "message": "Bilder werden gerade gespeichert"
+  },
+  "tip_clip_ok": {
+    "message": "Clipping erfolgreich"
+  },
+  "tip_token_miss": {
+    "message": "Bitte konfigurieren Sie das API-Token, bevor Sie den Inhalt speichern"
+  },
+  "tip_token_invalid": {
+    "message": "Ungültiges API-Token"
+  },
+  "tip_save_path_miss": {
+    "message": "Bitte wählen Sie den Speicherort, bevor Sie den Inhalt speichern"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Bitte starten Sie SiYuan und stellen Sie sicher, dass die Netzwerkverbindung funktioniert, bevor Sie es erneut versuchen"
+  }
+}

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Web clipping for SiYuan. "
+  },
+  "copy_to_siyuan": {
+    "message": "Copy to SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "Show Tip"
+  },
+  "siyuan_url": {
+    "message": "SiYuan URL"
+  },
+  "api_token": {
+    "message": "API token"
+  },
+  "save_path": {
+    "message": "Save path"
+  },
+  "save_path_placeholder": {
+    "message": "Input the keyword then Enter to search"
+  },
+  "tags": {
+    "message": "Tags"
+  },
+  "tags_placeholder": {
+    "message": "Use commas to separate multiple tags"
+  },
+  "assets": {
+    "message": "Download assets"
+  },
+  "exp": {
+    "message": "Show experimental features"
+  },
+  "exp_tips": {
+    "message": "*: Experimental features may be unstable. If there is a problem with clipping, consider switching it."
+  },
+  "exp_span": {
+    "message": "Detect span text newlines*"
+  },
+  "exp_bold": {
+    "message": "Detect bold style*"
+  },
+  "exp_italic": {
+    "message": "Detect italic style*"
+  },
+  "language": {
+    "message": "Language*"
+  },
+  "send": {
+    "message": "Send to SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "After installing the SiYuan extension for the first time, please refresh the page before using it"
+  },
+  "tip_clipping": {
+    "message": "Clipping, please wait a moment..."
+  },
+  "tip_clip_img": {
+    "message": "Clipping images"
+  },
+  "tip_clip_ok": {
+    "message": "Clipping successfully"
+  },
+  "tip_token_miss": {
+    "message": "Please config API token before clipping content"
+  },
+  "tip_token_invalid": {
+    "message": "Invalid API token"
+  },
+  "tip_save_path_miss": {
+    "message": "Please select save path before clipping content"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Please start SiYuan and ensure network connectivity before trying again"
+  }
+}

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Recorte web para SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "Copiar a SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "Mostrar consejo"
+  },
+  "siyuan_url": {
+    "message": "URL de SiYuan"
+  },
+  "api_token": {
+    "message": "Token API"
+  },
+  "save_path": {
+    "message": "Ruta de guardado"
+  },
+  "save_path_placeholder": {
+    "message": "Introduce la palabra clave y presiona Enter para buscar"
+  },
+  "tags": {
+    "message": "Etiquetas"
+  },
+  "tags_placeholder": {
+    "message": "Usa comas para separar múltiples etiquetas"
+  },
+  "assets": {
+    "message": "Descargar recursos"
+  },
+  "exp": {
+    "message": "Mostrar características experimentales"
+  },
+  "exp_tips": {
+    "message": "*: Las características experimentales pueden ser inestables. Si hay un problema con el recorte, intenta cambiarlo."
+  },
+  "exp_span": {
+    "message": "Detectar saltos de línea en span*"
+  },
+  "exp_bold": {
+    "message": "Detectar estilo negrita*"
+  },
+  "exp_italic": {
+    "message": "Detectar estilo cursiva*"
+  },
+  "language": {
+    "message": "Idioma*"
+  },
+  "send": {
+    "message": "Enviar a SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "Después de instalar la extensión SiYuan por primera vez, actualice la página antes de usarla"
+  },
+  "tip_clipping": {
+    "message": "Recortando, por favor espere..."
+  },
+  "tip_clip_img": {
+    "message": "Recortando imagen"
+  },
+  "tip_clip_ok": {
+    "message": "Recorte exitoso"
+  },
+  "tip_token_miss": {
+    "message": "Configure el token API antes de recortar el contenido"
+  },
+  "tip_token_invalid": {
+    "message": "Token API inválido"
+  },
+  "tip_save_path_miss": {
+    "message": "Seleccione la ruta de guardado antes de recortar el contenido"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Inicie SiYuan y asegúrese de que haya conectividad de red antes de intentar nuevamente"
+  }
+}

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Clipping web pour SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "Copier vers SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "Afficher les astuces"
+  },
+  "siyuan_url": {
+    "message": "URL de SiYuan"
+  },
+  "api_token": {
+    "message": "Jeton API"
+  },
+  "save_path": {
+    "message": "Chemin de sauvegarde"
+  },
+  "save_path_placeholder": {
+    "message": "Entrez le mot-clé puis appuyez sur Entrée pour rechercher"
+  },
+  "tags": {
+    "message": "Tags"
+  },
+  "tags_placeholder": {
+    "message": "Utilisez des virgules pour séparer plusieurs tags"
+  },
+  "assets": {
+    "message": "Télécharger les ressources"
+  },
+  "exp": {
+    "message": "Afficher les fonctionnalités expérimentales"
+  },
+  "exp_tips": {
+    "message": "*: Les fonctionnalités expérimentales peuvent être instables. Si vous avez un problème de clipping, essayez de les changer."
+  },
+  "exp_span": {
+    "message": "Détecter les sauts de ligne dans span*"
+  },
+  "exp_bold": {
+    "message": "Détecter le style gras*"
+  },
+  "exp_italic": {
+    "message": "Détecter le style italique*"
+  },
+  "language": {
+    "message": "Langue*"
+  },
+  "send": {
+    "message": "Envoyer à SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "Après avoir installé l'extension SiYuan pour la première fois, veuillez rafraîchir la page avant de l'utiliser"
+  },
+  "tip_clipping": {
+    "message": "Clipping, veuillez patienter..."
+  },
+  "tip_clip_img": {
+    "message": "Clipping des images"
+  },
+  "tip_clip_ok": {
+    "message": "Clipping réussi"
+  },
+  "tip_token_miss": {
+    "message": "Veuillez configurer le jeton API avant de recouper le contenu"
+  },
+  "tip_token_invalid": {
+    "message": "Jeton API invalide"
+  },
+  "tip_save_path_miss": {
+    "message": "Veuillez sélectionner le chemin de sauvegarde avant de recouper le contenu"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Veuillez démarrer SiYuan et vous assurer que la connexion réseau fonctionne avant de réessayer"
+  }
+}

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "סייוואן (SiYuan)"
+  },
+  "extension_description": {
+    "message": "חיתוך ווב עבור SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "העתק ל-SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "הצג טיפים"
+  },
+  "siyuan_url": {
+    "message": "כתובת URL של SiYuan"
+  },
+  "api_token": {
+    "message": "אסימון API"
+  },
+  "save_path": {
+    "message": "נתיב שמירה"
+  },
+  "save_path_placeholder": {
+    "message": "הזן מילה מפתח ואז לחץ Enter לחיפוש"
+  },
+  "tags": {
+    "message": "תגים"
+  },
+  "tags_placeholder": {
+    "message": "השתמש בפסיקים כדי להפריד תגיות"
+  },
+  "assets": {
+    "message": "הורד משאבים"
+  },
+  "exp": {
+    "message": "הצג תכונות ניסיוניות"
+  },
+  "exp_tips": {
+    "message": "*: תכונות ניסיוניות עשויות להיות לא יציבות. אם יש בעיה בחיתוך, נסה להחליף אותן."
+  },
+  "exp_span": {
+    "message": "גלה קפיצי שורות ב-span*"
+  },
+  "exp_bold": {
+    "message": "גלה סגנון מודגש*"
+  },
+  "exp_italic": {
+    "message": "גלה סגנון נטוי*"
+  },
+  "language": {
+    "message": "שפה*"
+  },
+  "send": {
+    "message": "שלח ל-SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "לאחר התקנת תוסף SiYuan לראשונה, אנא רענן את הדף לפני השימוש"
+  },
+  "tip_clipping": {
+    "message": "חיתוך, אנא המתן..."
+  },
+  "tip_clip_img": {
+    "message": "חיתוך תמונות"
+  },
+  "tip_clip_ok": {
+    "message": "החיתוך בוצע בהצלחה"
+  },
+  "tip_token_miss": {
+    "message": "אנא הגדר את אסימון ה-API לפני חיתוך התוכן"
+  },
+  "tip_token_invalid": {
+    "message": "אסימון API לא תקף"
+  },
+  "tip_save_path_miss": {
+    "message": "אנא בחר את נתיב השמירה לפני חיתוך התוכן"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "אנא הפעל את SiYuan וודא שהחיבור לרשת פעיל לפני שתנסה שוב"
+  }
+}

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Clip web per SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "Copia in SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "Mostra suggerimenti"
+  },
+  "siyuan_url": {
+    "message": "URL di SiYuan"
+  },
+  "api_token": {
+    "message": "Token API"
+  },
+  "save_path": {
+    "message": "Percorso di salvataggio"
+  },
+  "save_path_placeholder": {
+    "message": "Inserisci la parola chiave e premi Invio per cercare"
+  },
+  "tags": {
+    "message": "Tag"
+  },
+  "tags_placeholder": {
+    "message": "Usa le virgole per separare più tag"
+  },
+  "assets": {
+    "message": "Scarica risorse"
+  },
+  "exp": {
+    "message": "Mostra funzionalità sperimentali"
+  },
+  "exp_tips": {
+    "message": "*: Le funzionalità sperimentali potrebbero non essere stabili. Se hai problemi con il clipping, prova a cambiarle."
+  },
+  "exp_span": {
+    "message": "Rileva interruzioni di riga in span*"
+  },
+  "exp_bold": {
+    "message": "Rileva stile grassetto*"
+  },
+  "exp_italic": {
+    "message": "Rileva stile corsivo*"
+  },
+  "language": {
+    "message": "Lingua*"
+  },
+  "send": {
+    "message": "Invia a SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "Dopo aver installato l'estensione SiYuan per la prima volta, aggiorna la pagina prima di utilizzarla"
+  },
+  "tip_clipping": {
+    "message": "Clipping, attendi un momento..."
+  },
+  "tip_clip_img": {
+    "message": "Clipping delle immagini"
+  },
+  "tip_clip_ok": {
+    "message": "Clipping riuscito"
+  },
+  "tip_token_miss": {
+    "message": "Configura il token API prima di eseguire il clipping"
+  },
+  "tip_token_invalid": {
+    "message": "Token API non valido"
+  },
+  "tip_save_path_miss": {
+    "message": "Seleziona il percorso di salvataggio prima di eseguire il clipping"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Avvia SiYuan e assicurati che la connessione di rete funzioni prima di riprovare"
+  }
+}

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "SiYuan用のWebクリッピング"
+  },
+  "copy_to_siyuan": {
+    "message": "SiYuanにコピー"
+  },
+  
+  "show_tip": {
+    "message": "ヒントを表示"
+  },
+  "siyuan_url": {
+    "message": "SiYuanのURL"
+  },
+  "api_token": {
+    "message": "APIトークン"
+  },
+  "save_path": {
+    "message": "保存先"
+  },
+  "save_path_placeholder": {
+    "message": "キーワードを入力し、Enterキーを押して検索"
+  },
+  "tags": {
+    "message": "タグ"
+  },
+  "tags_placeholder": {
+    "message": "複数のタグをカンマで区切ってください"
+  },
+  "assets": {
+    "message": "リソースをダウンロード"
+  },
+  "exp": {
+    "message": "実験的な機能を表示"
+  },
+  "exp_tips": {
+    "message": "*: 実験的な機能は不安定な場合があります。クリッピングに問題がある場合は、切り替えてみてください。"
+  },
+  "exp_span": {
+    "message": "spanの改行スタイルを検出*"
+  },
+  "exp_bold": {
+    "message": "太字スタイルを検出*"
+  },
+  "exp_italic": {
+    "message": "斜体スタイルを検出*"
+  },
+  "language": {
+    "message": "言語*"
+  },
+  "send": {
+    "message": "SiYuanに送信"
+  },
+
+  "tip_first_time": {
+    "message": "SiYuan拡張機能を初めてインストールした後、使用する前にページを更新してください"
+  },
+  "tip_clipping": {
+    "message": "クリッピング中、しばらくお待ちください..."
+  },
+  "tip_clip_img": {
+    "message": "画像をクリッピング中"
+  },
+  "tip_clip_ok": {
+    "message": "クリッピング成功"
+  },
+  "tip_token_miss": {
+    "message": "コンテンツをクリッピングする前にAPIトークンを設定してください"
+  },
+  "tip_token_invalid": {
+    "message": "無効なAPIトークン"
+  },
+  "tip_save_path_miss": {
+    "message": "コンテンツをクリッピングする前に保存先を選択してください"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "SiYuanを起動し、ネットワーク接続が確立されていることを確認してから再試行してください"
+  }
+}

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Web clipping dla SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "Skopiuj do SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "Pokaż wskazówki"
+  },
+  "siyuan_url": {
+    "message": "URL SiYuan"
+  },
+  "api_token": {
+    "message": "Token API"
+  },
+  "save_path": {
+    "message": "Ścieżka zapisu"
+  },
+  "save_path_placeholder": {
+    "message": "Wprowadź słowo kluczowe i naciśnij Enter, aby wyszukać"
+  },
+  "tags": {
+    "message": "Tagi"
+  },
+  "tags_placeholder": {
+    "message": "Użyj przecinków, aby oddzielić tagi"
+  },
+  "assets": {
+    "message": "Pobierz zasoby"
+  },
+  "exp": {
+    "message": "Pokaż funkcje eksperymentalne"
+  },
+  "exp_tips": {
+    "message": "*: Funkcje eksperymentalne mogą być niestabilne. Jeśli napotkasz problem z clippingiem, spróbuj je przełączyć."
+  },
+  "exp_span": {
+    "message": "Wykryj łamanie linii w span*"
+  },
+  "exp_bold": {
+    "message": "Wykryj styl pogrubiony*"
+  },
+  "exp_italic": {
+    "message": "Wykryj styl kursywy*"
+  },
+  "language": {
+    "message": "Język*"
+  },
+  "send": {
+    "message": "Wyślij do SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "Po zainstalowaniu rozszerzenia SiYuan po raz pierwszy, odśwież stronę przed użyciem"
+  },
+  "tip_clipping": {
+    "message": "Trwa clipping, proszę czekać..."
+  },
+  "tip_clip_img": {
+    "message": "Clipping obrazów"
+  },
+  "tip_clip_ok": {
+    "message": "Clipping zakończony sukcesem"
+  },
+  "tip_token_miss": {
+    "message": "Skonfiguruj token API przed rozpoczęciem clippingu"
+  },
+  "tip_token_invalid": {
+    "message": "Nieprawidłowy token API"
+  },
+  "tip_save_path_miss": {
+    "message": "Wybierz ścieżkę zapisu przed rozpoczęciem clippingu"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Uruchom SiYuan i upewnij się, że połączenie z siecią jest aktywne przed ponowną próbą"
+  }
+}

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "SiYuan"
+  },
+  "extension_description": {
+    "message": "Веб-клиппинг для SiYuan."
+  },
+  "copy_to_siyuan": {
+    "message": "Копировать в SiYuan"
+  },
+  
+  "show_tip": {
+    "message": "Показать подсказку"
+  },
+  "siyuan_url": {
+    "message": "URL SiYuan"
+  },
+  "api_token": {
+    "message": "API токен"
+  },
+  "save_path": {
+    "message": "Путь сохранения"
+  },
+  "save_path_placeholder": {
+    "message": "Введите ключевое слово и нажмите Enter для поиска"
+  },
+  "tags": {
+    "message": "Теги"
+  },
+  "tags_placeholder": {
+    "message": "Используйте запятые для разделения нескольких тегов"
+  },
+  "assets": {
+    "message": "Скачать ресурсы"
+  },
+  "exp": {
+    "message": "Показать экспериментальные функции"
+  },
+  "exp_tips": {
+    "message": "*: Экспериментальные функции могут быть нестабильными. Если возникли проблемы с клиппингом, попробуйте изменить настройки."
+  },
+  "exp_span": {
+    "message": "Обнаружить разрывы строк в span*"
+  },
+  "exp_bold": {
+    "message": "Обнаружить стиль полужирного текста*"
+  },
+  "exp_italic": {
+    "message": "Обнаружить стиль курсивом*"
+  },
+  "language": {
+    "message": "Язык*"
+  },
+  "send": {
+    "message": "Отправить в SiYuan"
+  },
+
+  "tip_first_time": {
+    "message": "После первого установления расширения SiYuan, пожалуйста, обновите страницу перед использованием"
+  },
+  "tip_clipping": {
+    "message": "Клиппинг, подождите..."
+  },
+  "tip_clip_img": {
+    "message": "Клиппинг изображений"
+  },
+  "tip_clip_ok": {
+    "message": "Клиппинг выполнен успешно"
+  },
+  "tip_token_miss": {
+    "message": "Пожалуйста, настройте API токен перед клиппингом"
+  },
+  "tip_token_invalid": {
+    "message": "Неверный API токен"
+  },
+  "tip_save_path_miss": {
+    "message": "Пожалуйста, выберите путь сохранения перед клиппингом"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "Пожалуйста, запустите SiYuan и убедитесь в наличии сетевого соединения перед повторной попыткой"
+  }
+}

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "思源(SiYuan)"
+  },
+  "extension_description": {
+    "message": "思源笔记网页剪藏。"
+  },
+  "copy_to_siyuan": {
+    "message": "复制到思源(SiYuan)"
+  },
+  
+  "show_tip": {
+    "message": "显示提示"
+  },
+  "siyuan_url": {
+    "message": "思源(SiYuan) URL"
+  },
+  "api_token": {
+    "message": "API令牌(API token)"
+  },
+  "save_path": {
+    "message": "保存路径"
+  },
+  "save_path_placeholder": {
+    "message": "输入关键字然后按回车键开始搜索"
+  },
+  "tags": {
+    "message": "标签"
+  },
+  "tags_placeholder": {
+    "message": "使用逗号分隔多个标签"
+  },
+  "assets": {
+    "message": "下载资源"
+  },
+  "exp": {
+    "message": "显示实验性特性"
+  },
+  "exp_tips": {
+    "message": "*: 实验性特性可能不稳定。如果剪藏遇到了问题可以考虑切换对应的开关看看能否解决。"
+  },
+  "exp_span": {
+    "message": "识别span节点的换行样式*"
+  },
+  "exp_bold": {
+    "message": "识别粗体样式*"
+  },
+  "exp_italic": {
+    "message": "识别斜体样式*"
+  },
+  "language": {
+    "message": "语言*"
+  },
+  "send": {
+    "message": "发送到思源(SiYuan)"
+  },
+
+  "tip_first_time": {
+    "message": "首次安装思源扩展后，请刷新页面后再使用"
+  },
+  "tip_clipping": {
+    "message": "剪藏中, 请稍等..."
+  },
+  "tip_clip_img": {
+    "message": "剪藏图像中"
+  },
+  "tip_clip_ok": {
+    "message": "剪藏成功"
+  },
+  "tip_token_miss": {
+    "message": "剪藏前请先配置API令牌(API token)"
+  },
+  "tip_token_invalid": {
+    "message": "无效的API令牌(API token)"
+  },
+  "tip_save_path_miss": {
+    "message": "剪藏前请先选择保存路径"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "请启动思源并确保网络连通后再试"
+  }
+}

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -1,0 +1,82 @@
+{
+  "extension_name": {
+    "message": "思源(SiYuan)"
+  },
+  "extension_description": {
+    "message": "思源筆記網頁剪藏。"
+  },
+  "copy_to_siyuan": {
+    "message": "複製到思源(SiYuan)"
+  },
+  
+  "show_tip": {
+    "message": "顯示提示"
+  },
+  "siyuan_url": {
+    "message": "思源(SiYuan) URL"
+  },
+  "api_token": {
+    "message": "API令牌(API token)"
+  },
+  "save_path": {
+    "message": "儲存路徑"
+  },
+  "save_path_placeholder": {
+    "message": "輸入關鍵字然後按回車鍵開始搜尋"
+  },
+  "tags": {
+    "message": "標籤"
+  },
+  "tags_placeholder": {
+    "message": "使用逗號分隔多個標籤"
+  },
+  "assets": {
+    "message": "下載資源"
+  },
+  "exp": {
+    "message": "顯示實驗性特性"
+  },
+  "exp_tips": {
+    "message": "*: 實驗性特性可能不穩定。如果剪藏遇到問題，可以考慮切換對應的開關看看能否解決。"
+  },
+  "exp_span": {
+    "message": "識別span節點的換行樣式*"
+  },
+  "exp_bold": {
+    "message": "識別粗體樣式*"
+  },
+  "exp_italic": {
+    "message": "識別斜體樣式*"
+  },
+  "language": {
+    "message": "語言*"
+  },
+  "send": {
+    "message": "發送到思源(SiYuan)"
+  },
+
+  "tip_first_time": {
+    "message": "首次安裝思源擴展後，請刷新頁面後再使用"
+  },
+  "tip_clipping": {
+    "message": "剪藏中，請稍等..."
+  },
+  "tip_clip_img": {
+    "message": "剪藏圖像中"
+  },
+  "tip_clip_ok": {
+    "message": "剪藏成功"
+  },
+  "tip_token_miss": {
+    "message": "剪藏前請先配置API令牌(API token)"
+  },
+  "tip_token_invalid": {
+    "message": "無效的API令牌(API token)"
+  },
+  "tip_save_path_miss": {
+    "message": "剪藏前請先選擇儲存路徑"
+  },
+  "tip_siyuan_kernel_unavailable": {
+    "message": "請啟動思源並確保網路連通後再試"
+  }
+}

--- a/background.js
+++ b/background.js
@@ -1,7 +1,8 @@
 chrome.contextMenus.removeAll(function () {
+    const title = chrome.i18n.getMessage("copy_to_siyuan");
     chrome.contextMenus.create({
         id: 'copy-to-siyuan',
-        title: 'Copy to SiYuan',
+        title: title,
         contexts: ['selection', 'image'],
     })
 
@@ -49,8 +50,8 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
     }).then((response) => {
         if (response.redirected) {
             chrome.tabs.sendMessage(requestData.tabId, {
-                'func': 'tip',
-                'msg': 'Invalid API token',
+                'func': 'tipKey',
+                'msg': 'tip_token_invalid',
                 'tip': 'tip',
             })
         }
@@ -127,8 +128,8 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
             }).then((response) => {
                 if (0 === response.code) {
                     chrome.tabs.sendMessage(requestData.tabId, {
-                        'func': 'tip',
-                        'msg': "Clipping successfully",
+                        'func': 'tipKey',
+                        'msg': "tip_clip_ok",
                         'tip': requestData.tip,
                     })
 
@@ -157,8 +158,8 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
     }).catch((e) => {
         console.error(e)
         chrome.tabs.sendMessage(requestData.tabId, {
-            'func': 'tip',
-            'msg': "Please start SiYuan and ensure network connectivity before trying again 请启动思源并确保网络连通后再试",
+            'func': 'tipKey',
+            'msg': "tip_siyuan_kernel_unavailable",
             'tip': "tip",
         });
     })

--- a/content.js
+++ b/content.js
@@ -6,6 +6,11 @@ document.addEventListener('DOMContentLoaded', function () {
                 return
             }
 
+            if ('tipKey' === request.func && request.tip) {
+                siyuanShowTipByKey(request.msg, request.timeout)
+                return
+            }
+
             if ('copy2Clipboard' === request.func) {
                 await copyToClipboard(request.data)
                 return
@@ -15,7 +20,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 return
             }
 
-            siyuanShowTip('Clipping, please wait a moment...')
+            siyuanShowTipByKey("tip_clipping")
 
             const selection = window.getSelection()
             if (selection && 0 < selection.rangeCount) {
@@ -76,6 +81,11 @@ const siyuanShowTip = (msg, timeout) => {
     tipTimeoutId = setTimeout(() => {
         siyuanClearTip();
     }, timeout);
+}
+
+// Add i18n support https://github.com/siyuan-note/siyuan/issues/13559
+const siyuanShowTipByKey = (msgKey, timeout) => {
+    siyuanShowTip(chrome.i18n.getMessage(msgKey), timeout);
 }
 
 const siyuanClearTip = () => {
@@ -328,12 +338,12 @@ const siyuanSendUpload = async (tempElement, tabId, srcUrl, type, article, href)
         expItalic: false,
     }, async function (items) {
         if (!items.token) {
-            siyuanShowTip('Please config API token before clipping content 剪藏前请先配置 API token')
+            siyuanShowTipByKey("tip_token_miss")
             return
         }
 
         if (!items.notebook) {
-            siyuanShowTip('Please select save path before clipping content 剪藏前请先选择保存路径')
+            siyuanShowTipByKey("tip_save_path_miss")
             return
         }
 
@@ -388,7 +398,7 @@ const siyuanSendUpload = async (tempElement, tabId, srcUrl, type, article, href)
         let fetchFileErr = false;
         for (let i = 0; i < srcList.length; i++) {
             let src = srcList[i]
-            siyuanShowTip('Clipping images [' + i + '/' + srcList.length + ']...')
+            siyuanShowTip(chrome.i18n.getMessage("tip_clip_img") + ' [' + i + '/' + srcList.length + ']...');
             let response;
             try {
                 // Wikipedia 使用图片原图 https://github.com/siyuan-note/siyuan/issues/11640

--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
   "manifest_version": 3,
   "minimum_chrome_version": "91",
   "homepage_url": "https://github.com/siyuan-note/siyuan-chrome",
+  "default_locale": "en",
   "action": {
     "default_title": "SiYuan",
     "default_popup": "options.html"
@@ -34,8 +35,8 @@
   "host_permissions": [
     "*://*/*"
   ],
-  "name": "SiYuan",
+  "name": "__MSG_extension_name__",
   "options_page": "options.html",
-  "description": "Web clipping for SiYuan. 思源笔记网页剪藏。",
-  "version": "1.7.1"
+  "description": "__MSG_extension_description__",
+  "version": "1.7.2"
 }

--- a/options.html
+++ b/options.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <style>
@@ -381,13 +381,13 @@
 <div style="max-width: 256px">
     <div id="log" style="color: #d23f31;margin-bottom: 16px"></div>
     <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
-        <div style="flex: 1">Show Tip</div>
+        <div style="flex: 1" data-i18n="show_tip">Show Tip</div>
         <input class="b3-switch" id="showTip" checked type="checkbox">
     </label>
-    <div class="b3-label">SiYuan URL</div>
+    <div class="b3-label" data-i18n="siyuan_url">SiYuan URL</div>
     <input id="ip" class="b3-text-field">
     <div class="fn__hr"></div>
-    <div class="b3-label">API token</div>
+    <div class="b3-label" data-i18n="api_token">API token</div>
     <div style="position: relative">
         <input id="token" type="password" class="b3-text-field" style="padding-left: 28px">
         <svg class="b3-icon" viewBox="0 0 32 32">
@@ -395,41 +395,58 @@
         </svg>
     </div>
     <div class="fn__hr"></div>
-    <div class="b3-label">Save path</div>
-    <input class="b3-text-field" id="searchDoc" placeholder="Input the keyword then Enter to search"/>
+    <div class="b3-label" data-i18n="save_path">Save path</div>
+    <input class="b3-text-field" id="searchDoc" data-i18n="save_path_placeholder" placeholder="Input the keyword then Enter to search"/>
     <div class="fn__hr"></div>
     <select class="b3-select" id="parentDoc"></select>
     <div class="fn__hr"></div>
-    <div class="b3-label">Tags</div>
-    <input class="b3-text-field" id="tags" placeholder="Use commas to separate multiple tags" />
+    <div class="b3-label" data-i18n="tags">Tags</div>
+    <input class="b3-text-field" id="tags" data-i18n="tags_placeholder" placeholder="Use commas to separate multiple tags" />
     <div class="fn__hr"></div>
     <div class="fn__hr"></div>
     <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
-        <div style="flex: 1">Download assets</div>
+        <div style="flex: 1" data-i18n="assets">Download assets</div>
         <input class="b3-switch" id="assets" checked type="checkbox">
     </label>
     <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
-        <div class="b3-label" style="flex: 1">Show experimental features</div>
+        <div class="b3-label" style="flex: 1" data-i18n="exp">Show experimental features</div>
         <input class="b3-switch" id="exp" type="checkbox">
     </label>
     <div id="expGroup" style="display: none;">
-      <div class="b3-label" style="font-size: 14px; color: red;">*: Experimental features may be unstable. If there is a problem with clipping, consider switching it.</div>
+      <div class="b3-label" style="font-size: 14px; color: red;" data-i18n="exp_tips">*: Experimental features may be unstable. If there is a problem with clipping, consider switching it.</div>
       <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
-          <div style="flex: 1">Detect span text newlines*</div>
+          <div style="flex: 1" data-i18n="exp_span">Detect span text newlines*</div>
           <input class="b3-switch" id="expSpan" checked type="checkbox">
       </label>
       <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
-          <div style="flex: 1">Detect bold style*</div>
+          <div style="flex: 1" data-i18n="exp_bold">Detect bold style*</div>
           <input class="b3-switch" id="expBold" type="checkbox">
       </label>
       <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
-          <div style="flex: 1">Detect italic style*</div>
+          <div style="flex: 1" data-i18n="exp_italic">Detect italic style*</div>
           <input class="b3-switch" id="expItalic" type="checkbox">
+      </label>
+      <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
+          <div style="flex: 1" data-i18n="language">Language*</div>
+          <select style="flex: 1" class="b3-select" id="language">
+            <option value="ar">العربية</option>
+            <option value="de">Deutsch</option>
+            <option value="en" selected>English</option>
+            <option value="es">Español</option>
+            <option value="fr">Français</option>
+            <option value="he">עברית</option>
+            <option value="it">Italiano</option>
+            <option value="ja">日本語</option>
+            <option value="pl">Polski</option>
+            <option value="ru">Русский</option>
+            <option value="zh_TW">繁體中文</option>
+            <option value="zh_CN">简体中文</option>
+          </select>
       </label>
     </div>
     <div class="fn__hr"></div>
     <div class="fn__hr"></div>
-    <button class="b3-button" id="send">Send to SiYuan</button>
+    <button class="b3-button" id="send" data-i18n="send">Send to SiYuan</button>
 </div>
 <script src="popup.js"></script>
 </body>


### PR DESCRIPTION
根据 https://github.com/siyuan-note/siyuan/issues/13559 的讨论，增加了i18n框架

针对目前SiYuan主仓已支持的12种语言添加了支持

但是这里有一些尚未改好：
1. 如 https://github.com/siyuan-note/siyuan/issues/13559#issuecomment-2561729722 里面说明的，
目前仅支持option.html界面配置不随着浏览器主语言框架变动，保存的语言配置也仅针对这个
2. **对于siyuanShowTip来说，目前翻译是跟随浏览器主语言，设置选项对此不会生效**
3. 默认语言是英语English(en)
4. 除了英语(en)和简体中文(zh_CN)，其他10种是采用AI+谷歌翻译的形式翻译的，可能有错误，我也只是来回翻译回中文和英语检查了下
5. **已知阿拉伯语(ar)和希伯来语(he)应该文字方向是RTL的，没接触过虽然翻译了但布局不知道怎么调整，就没动**
6. 语言设置默认就是自动获取浏览器语言，除非不支持语言才会换回英语
7. 其实也可以从SiYuan Kernel获取它的语言配置，以后研究一下
8. 语言设置也是实验性选项，展开后可见
9. 下面给出几种语言的界面截图
![image](https://github.com/user-attachments/assets/ebb99160-2b1c-4b92-8655-c8508e2baa68)
![image](https://github.com/user-attachments/assets/26b03ffc-bc9d-435e-88de-42675b16cd27)
![image](https://github.com/user-attachments/assets/3873868b-13d9-4433-b9b5-035fb5dae074)
