### PR TITLE
Template settings fix

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -103,5 +103,8 @@
   },
   "template_help": {
     "message": "Available variables:<br>${title} - Page title<br>${url} - Page URL<br>${siteName} - Site name<br>${date} - Current date (yyyy-MM-dd)<br>${time} - Current time (HH:mm)<br>${tags} - Tags<br>${excerpt} - Page excerpt<br>${content} - Page content"
+  },
+  "template_restore_default": {
+    "message": "Restore default"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -103,5 +103,8 @@
   },
   "template_help": {
     "message": "可用变量：<br>${title} - 页面标题<br>${url} - 页面URL<br>${siteName} - 网站名称<br>${date} - 当前日期 (yyyy-MM-dd)<br>${time} - 当前时间 (HH:mm)<br>${tags} - 标签<br>${excerpt} - 页面摘要<br>${content} - 页面内容"
+  },
+  "template_restore_default": {
+    "message": "恢复默认"
   }
 }

--- a/background.js
+++ b/background.js
@@ -167,7 +167,16 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
             let title = requestData.title ? requestData.title : 'Untitled'
             title = title.replaceAll("/", "／")
             chrome.storage.sync.get({
-                clipTemplate: '---\n\n- ${title}${siteName ? " - " + siteName : ""}\n- [${urlDecoded}](${url}) \n- ${excerpt}\n- ${date} ${time}\n\n---\n\n${content}',
+                clipTemplate: '---\n' +
+                    '\n' +
+                    '- ${title}${siteName ? " - " + siteName : ""}\n' +
+                    '- [${urlDecoded}](${url}) \n' +
+                    '${excerpt ? "- " + excerpt : ""}\n' +
+                    '- ${date} ${time}\n' +
+                    '\n' +
+                    '---\n' +
+                    '\n' +
+                    '${content}',
             }, (items) => {
                 let excerpt = requestData.excerpt.trim()
                 if ("" !== excerpt) {

--- a/manifest.json
+++ b/manifest.json
@@ -43,5 +43,5 @@
   "name": "__MSG_extension_name__",
   "options_page": "options.html",
   "description": "__MSG_extension_description__",
-  "version": "1.12.12"
+  "version": "1.12.13"
 }

--- a/options.html
+++ b/options.html
@@ -573,6 +573,7 @@
                 <!-- 这里将由JS填充模板变量的帮助信息 -->
             </div>
             <div class="template-buttons">
+                <button id="restoreTemplate" class="b3-button" style="background-color: #e0e0e0; color: #333; width: auto;" data-i18n="template_restore_default">Restore default</button>
                 <button id="cancelTemplate" class="b3-button"
                     style="background-color: #e0e0e0; color: #333; width: auto;"
                     data-i18n="template_cancel">Cancel</button>

--- a/popup.js
+++ b/popup.js
@@ -229,7 +229,16 @@ document.addEventListener('DOMContentLoaded', () => {
         expRemoveImgLink: false,
         expListDocTree: false,
         expSvgToImg: false,
-        clipTemplate: '---\n\n- ${title}${siteName ? " - " + siteName : ""}\n- [${urlDecoded}](${url}) \n- ${excerpt}\n- ${date} ${time}\n\n---\n\n${content}',
+        clipTemplate: '---\n' +
+            '\n' +
+            '- ${title}${siteName ? " - " + siteName : ""}\n' +
+            '- [${urlDecoded}](${url}) \n' +
+            '${excerpt ? "- " + excerpt : ""}\n' +
+            '- ${date} ${time}\n' +
+            '\n' +
+            '---\n' +
+            '\n' +
+            '${content}',
     }, async function (items) {
         siyuanLoadLanguageFile(items.langCode, (data) => {
             siyuanTranslateDOM(data); // 在这里使用加载的i18n数据

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,17 @@
+// 默认剪藏模板（用于首次加载与恢复默认）
+function getDefaultTemplate() {
+    return '---\n' +
+        '\n' +
+        '- ${title}${siteName ? " - " + siteName : ""}\n' +
+        '- [${urlDecoded}](${url}) \n' +
+        '${excerpt ? "- " + excerpt : ""}\n' +
+        '- ${date} ${time}\n' +
+        '\n' +
+        '---\n' +
+        '\n' +
+        '${content}';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const ipElement = document.getElementById('ip')
     const tokenElement = document.getElementById('token')
@@ -76,6 +90,15 @@ document.addEventListener('DOMContentLoaded', () => {
             // 打开模板配置弹窗
             const templateModal = document.getElementById('templateModal')
             if (templateModal) {
+                // 打开时预填充当前模板（无则回退默认）
+                const templateTextArea = document.getElementById('templateText')
+                if (templateTextArea) {
+                    chrome.storage.sync.get({
+                        clipTemplate: getDefaultTemplate(),
+                    }, (t) => {
+                        templateTextArea.value = t.clipTemplate || getDefaultTemplate()
+                    })
+                }
                 templateModal.style.display = 'block'
             }
         })
@@ -101,6 +124,23 @@ document.addEventListener('DOMContentLoaded', () => {
                             templateSavedMsg.style.display = 'none'
                         }, 2000)
                     }
+                }
+            })
+        })
+    }
+
+    // 添加模板恢复默认按钮事件
+    const restoreTemplateBtn = document.getElementById('restoreTemplate')
+    if (restoreTemplateBtn) {
+        restoreTemplateBtn.addEventListener('click', () => {
+            const templateTextArea = document.getElementById('templateText')
+            const def = getDefaultTemplate()
+            if (templateTextArea) templateTextArea.value = def
+            chrome.storage.sync.set({ clipTemplate: def }, () => {
+                const templateSavedMsg = document.getElementById('templateSavedMsg')
+                if (templateSavedMsg) {
+                    templateSavedMsg.style.display = 'block'
+                    setTimeout(() => { templateSavedMsg.style.display = 'none' }, 2000)
                 }
             })
         })
@@ -229,16 +269,7 @@ document.addEventListener('DOMContentLoaded', () => {
         expRemoveImgLink: false,
         expListDocTree: false,
         expSvgToImg: false,
-        clipTemplate: '---\n' +
-            '\n' +
-            '- ${title}${siteName ? " - " + siteName : ""}\n' +
-            '- [${urlDecoded}](${url}) \n' +
-            '${excerpt ? "- " + excerpt : ""}\n' +
-            '- ${date} ${time}\n' +
-            '\n' +
-            '---\n' +
-            '\n' +
-            '${content}',
+        clipTemplate: getDefaultTemplate(),
     }, async function (items) {
         siyuanLoadLanguageFile(items.langCode, (data) => {
             siyuanTranslateDOM(data); // 在这里使用加载的i18n数据

--- a/popup.js
+++ b/popup.js
@@ -276,39 +276,62 @@ document.addEventListener('DOMContentLoaded', () => {
     })
 })
 
-const updateSearch = () => {
+const updateSearch = async () => {
     const ipElement = document.getElementById('ip')
     const tokenElement = document.getElementById('token')
     const searchDocElement = document.getElementById('searchDoc')
     const parentDocElement = document.getElementById('parentDoc')
 
-    fetch(ipElement.value + '/api/filetree/searchDocs', {
-        method: 'POST',
-        redirect: "manual",
-        headers: {
-            'Authorization': 'Token ' + tokenElement.value,
-        },
-        body: JSON.stringify({
-            "k": searchDocElement.value,
-            "flashcard": false
+    // Validate token
+    if (!tokenElement.value || tokenElement.value.trim() === '') {
+        const msg = chrome.i18n.getMessage('tip_token_miss') || 'Please configure the API token before clipping content'
+        document.getElementById('log').innerHTML = msg
+        return
+    }
+
+    // Normalize base URL
+    let base = (ipElement.value || '').trim()
+    if (!base) base = 'http://127.0.0.1:6806'
+    if (!/^https?:\/\//i.test(base)) base = 'http://' + base
+    while (base.endsWith('/')) base = base.slice(0, -1)
+
+    try {
+        const response = await fetch(base + '/api/filetree/searchDocs', {
+            method: 'POST',
+            headers: {
+                'Authorization': 'Token ' + tokenElement.value,
+                'Content-Type': 'application/json; charset=UTF-8',
+            },
+            body: JSON.stringify({
+                k: searchDocElement.value || '',
+                flashcard: false,
+            })
         })
-    }).then((response) => {
+        if (response.status === 401 || response.status === 403) {
+            const msg = chrome.i18n.getMessage('tip_token_invalid') || 'Invalid API token'
+            document.getElementById('log').innerHTML = msg
+            return
+        }
         if (response.status !== 200) {
-            document.getElementById('log').innerHTML = "Authentication failed, please check API token"
+            const msg = chrome.i18n.getMessage('tip_siyuan_kernel_unavailable') || 'Please start SiYuan and ensure network connectivity before trying again'
+            document.getElementById('log').innerHTML = msg
             return
         }
-
-        document.getElementById('log').innerHTML = ""
-        return response.json()
-    }).then((response) => {
-        if (0 !== response.code) {
-            document.getElementById('log').innerHTML = "Search docs failed"
+        document.getElementById('log').innerHTML = ''
+        let data
+        try {
+            data = await response.json()
+        } catch (e) {
+            const msg = chrome.i18n.getMessage('tip_siyuan_kernel_unavailable') || 'Please start SiYuan and ensure network connectivity before trying again'
+            document.getElementById('log').innerHTML = msg
             return
         }
-
+        if (!data || data.code !== 0 || !Array.isArray(data.data)) {
+            return
+        }
         let optionsHTML = ''
-        response.data.forEach(doc => {
-            const parentDoc = doc.path.substring(doc.path.toString().lastIndexOf('/') + 1).replace(".sy", '')
+        data.data.forEach(doc => {
+            const parentDoc = String(doc.path).substring(String(doc.path).lastIndexOf('/') + 1).replace('.sy', '')
             let selected = ""
             if (parentDocElement.dataset.notebook === doc.box && parentDocElement.dataset.parent === parentDoc &&
                 parentDocElement.dataset.parenthpath === doc.hPath) {
@@ -319,13 +342,13 @@ const updateSearch = () => {
         parentDocElement.innerHTML = optionsHTML
 
         if (parentDocElement.selectedOptions && parentDocElement.selectedOptions.length > 0) {
-            let selected = parentDocElement.querySelector('option[selected]')
-            if (!selected) {
-                selected = parentDocElement.selectedOptions[0]
+            let selectedOpt = parentDocElement.querySelector('option[selected]')
+            if (!selectedOpt) {
+                selectedOpt = parentDocElement.selectedOptions[0]
                 chrome.storage.sync.set({
-                    notebook: selected.getAttribute("data-notebook"),
-                    parentDoc: selected.getAttribute("data-parent"),
-                    parentHPath: selected.innerText,
+                    notebook: selectedOpt.getAttribute('data-notebook'),
+                    parentDoc: selectedOpt.getAttribute('data-parent'),
+                    parentHPath: selectedOpt.innerText,
                 })
             }
         } else {
@@ -335,11 +358,16 @@ const updateSearch = () => {
                 parentHPath: ''
             })
         }
-    })
+    } catch (e) {
+        const msg = chrome.i18n.getMessage('tip_siyuan_kernel_unavailable') || 'Please start SiYuan and ensure network connectivity before trying again'
+        document.getElementById('log').innerHTML = msg
+    }
 }
 
 const escapeHtml = (unsafe) => {
-    return unsafe
+    if (unsafe == null) return ''
+    const s = String(unsafe)
+    return s
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
@@ -385,10 +413,30 @@ const siyuanGetReadability = async (tabId) => {
 let siyuanLangData = null;
 let siyuanLangCode = null;
 
+function siyuanResolveLocale(lang) {
+    try {
+        const available = ['ar','de','en','es','fr','he','it','ja','pl','ru','zh_CN','zh_TW'];
+        if (!lang) return 'en';
+        let code = String(lang).replace('-', '_');
+        if (code.toLowerCase().startsWith('zh')) {
+            const lower = code.toLowerCase();
+            if (lower.includes('tw') || lower.includes('hk') || lower.includes('mo') || lower.includes('hant')) {
+                return 'zh_TW';
+            }
+            return 'zh_CN';
+        }
+        if (available.includes(code)) return code;
+        const base = code.split('_')[0];
+        if (available.includes(base)) return base;
+        return 'en';
+    } catch (e) {
+        return 'en';
+    }
+}
+
 function siyuanGetDefaultLangCode() {
-    const langCode = navigator.language || navigator.userLanguage || chrome.runtime.getManifest().default_locale;
-    const normalizedLangCode = langCode.replace('-', '_');
-    return normalizedLangCode;
+    const raw = navigator.language || navigator.userLanguage || chrome.runtime.getManifest().default_locale || 'en';
+    return siyuanResolveLocale(raw);
 }
 
 // 合并当前语言和英语（en）翻译的函数
@@ -401,15 +449,14 @@ async function siyuanMergeTranslations(translations, langCode) {
 
     // 如果当前语言不是英语，则加载英语翻译文件
     if (langCode !== defaultLangCode) {
-        const enTranslationFile = chrome.runtime.getURL(`_locales/${langCode}/messages.json`);
+        const enTranslationFile = chrome.runtime.getURL(`_locales/${defaultLangCode}/messages.json`);
         try {
-            // 异步加载英语翻译文件
             const response = await fetch(enTranslationFile);
             if (!response.ok) {
                 throw new Error('Network response was not ok');
             }
-            const enData = await response.json(); // 解析JSON
-            defaultTranslations = enData; // 保存英语翻译数据
+            const enData = await response.json();
+            defaultTranslations = enData;
         } catch (err) {
             console.error("Failed to load English translation:", err);
         }
@@ -421,58 +468,52 @@ async function siyuanMergeTranslations(translations, langCode) {
 }
 
 async function siyuanLoadLanguageFile(langCode, callback) {
-    // 检查是否已经加载过数据
-    if (siyuanLangData && siyuanLangCode === langCode) {
-        // 如果已经加载，直接调用回调并传递数据
+    const normalized = (typeof siyuanResolveLocale === 'function') ? siyuanResolveLocale(langCode) : (langCode || 'en');
+
+    if (siyuanLangData && siyuanLangCode === normalized) {
         callback(siyuanLangData);
         return;
     }
 
-    // 先加载当前语言的翻译文件
-    try {
-        const translationFile = chrome.runtime.getURL(`_locales/${langCode}/messages.json`);
-        const response = await fetch(translationFile);
-        if (!response.ok) {
-            throw new Error('Network response was not ok');
+    const tryLoad = async (code) => {
+        try {
+            const translationFile = chrome.runtime.getURL(`_locales/${code}/messages.json`);
+            const response = await fetch(translationFile);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return await response.json();
+        } catch (e) {
+            return null;
         }
-        const data = await response.json(); // 解析JSON
+    };
 
-        // 加载成功，检查并补充缺失的翻译
-        // 先把加载的翻译数据保存在全局变量中
-        const mergedData = await siyuanMergeTranslations(data, langCode); // 等待合并翻译
-        siyuanLangData = mergedData;
-        siyuanLangCode = langCode;
+    let data = await tryLoad(normalized);
+    if (!data) data = await tryLoad('en');
+    if (!data) data = {};
 
-        // 调用回调并传递数据
-        callback(mergedData);
-
-    } catch (error) {
-        console.error('There was a problem with the fetch operation:', error);
-    }
+    const mergedData = await siyuanMergeTranslations(data, normalized);
+    siyuanLangData = mergedData;
+    siyuanLangCode = normalized;
+    callback(mergedData);
 }
 
 function siyuanTranslateDOM(translations) {
+    const t = translations || {};
     const elements = document.querySelectorAll('[data-i18n]');
     elements.forEach(element => {
         const key = element.getAttribute('data-i18n');
-        if (!translations[key] || !translations[key].message) {
-            console.warn(`siyuanTranslateDOM Missing translation for key: ${key}`);
+        const msg = t[key] && t[key].message ? t[key].message : null;
+        if (!msg) {
             return;
         }
-
-        const translation = translations[key].message;
-        if (element.placeholder !== undefined) {
-            // 翻译 placeholder 属性
-            element.placeholder = translation;
+        if ('placeholder' in element) {
+            element.placeholder = msg;
         } else {
-            // 翻译 textContent
-            element.textContent = translation;
+            element.textContent = msg;
         }
     });
 
-    // 确保模板帮助文本也被更新
     const templateHelp = document.getElementById('templateHelp');
-    if (templateHelp && translations.template_help) {
-        templateHelp.innerHTML = translations.template_help.message;
+    if (templateHelp && t.template_help && t.template_help.message) {
+        templateHelp.innerHTML = t.template_help.message;
     }
 }


### PR DESCRIPTION
1. "Clipping template" setting showed an empty box by default. It now shows the default clipping template which can be modified by the user. The variables available to the clipper are listed below the box.

2. "Clipping template" was not possible to restore to default. If user entered a new template text, then removed it (revert to empty box), the default template was not restored. Now there is a button for restoring the original template.

3. error log messages: while testing this change, a timer was sending a message but failing. I have added a safer way for those messages to send so the error log remains clear

4. this change is significant enough to suggest increasing the version number,  but I am not sure if you want to do that.

Thank you!

---

（谷歌翻译）

1. “剪辑模板”设置默认显示一个空框。现在显示默认的剪辑模板，用户可以修改。剪辑器可用的变量列在框下方。

2. “剪辑模板”无法恢复为默认模板。如果用户输入了新的模板文本，然后将其删除（恢复为空框），则无法恢复默认模板。现在有一个按钮可以恢复原始模板。

3. 错误日志消息：在测试此更改时，一个计时器正在发送消息，但失败了。我添加了一种更安全的发送这些消息的方式，以便错误日志保持清晰。

4. 此更改非常重要，建议提高版本号，但我不确定您是否愿意这样做。

谢谢！