### PR TITLE
Template settings fix

### DIFF
--- a/_locales/ar/messages.json
+++ b/_locales/ar/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "أدخل كلمة مفتاحية للبحث في قاعدة البيانات"
+  },
+  "save_path_none": {
+    "message": "بدون"
+  },
+  "database_none": {
+    "message": "بدون"
   }
 }

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "Suchbegriff für Datenbank eingeben"
+  },
+  "save_path_none": {
+    "message": "Keine"
+  },
+  "database_none": {
+    "message": "Keine"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -110,6 +110,9 @@
   "template_restore_default": {
     "message": "Restore default"
   },
+  "template_restore_default": {
+    "message": "Restore default"
+  },
   "database_label": {
     "message": "Add to database"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -108,6 +108,12 @@
     "message": "Add to database"
   },
   "database_search_placeholder": {
-    "message": "Input the keyword to search database"
+    "message": "Input the keyword then Enter to search"
+  },
+  "save_path_none": {
+    "message": "None"
+  },
+  "database_none": {
+    "message": "None"
   }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -113,6 +113,9 @@
   "template_restore_default": {
     "message": "Restore default"
   },
+  "template_restore_default": {
+    "message": "Restore default"
+  },
   "database_label": {
     "message": "Add to database"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -104,6 +104,9 @@
   "template_help": {
     "message": "Available variables:<br>${title} - Page title<br>${url} - Page URL<br>${siteName} - Site name<br>${date} - Current date (yyyy-MM-dd)<br>${time} - Current time (HH:mm)<br>${tags} - Tags<br>${excerpt} - Page excerpt<br>${content} - Page content"
   },
+  "template_restore_default": {
+    "message": "Restore default"
+  },
   "database_label": {
     "message": "Add to database"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -107,6 +107,9 @@
   "template_restore_default": {
     "message": "Restore default"
   },
+  "template_restore_default": {
+    "message": "Restore default"
+  },
   "database_label": {
     "message": "Add to database"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "Ingrese palabra clave para buscar base de datos"
+  },
+  "save_path_none": {
+    "message": "Ninguno"
+  },
+  "database_none": {
+    "message": "Ninguno"
   }
 }

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "Saisir un mot-clé pour rechercher dans la base de données"
+  },
+  "save_path_none": {
+    "message": "Aucun"
+  },
+  "database_none": {
+    "message": "Aucun"
   }
 }

--- a/_locales/he/messages.json
+++ b/_locales/he/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "הזן מילת מפתח לחיפוש במסד הנתונים"
+  },
+  "save_path_none": {
+    "message": "אין"
+  },
+  "database_none": {
+    "message": "אין"
   }
 }

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "Inserisci parola chiave per cercare nel database"
+  },
+  "save_path_none": {
+    "message": "Nessuno"
+  },
+  "database_none": {
+    "message": "Nessuno"
   }
 }

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "キーワードを入力してデータベースを検索"
+  },
+  "save_path_none": {
+    "message": "なし"
+  },
+  "database_none": {
+    "message": "なし"
   }
 }

--- a/_locales/pl/messages.json
+++ b/_locales/pl/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "Wpisz słowo kluczowe, aby wyszukać bazę danych"
+  },
+  "save_path_none": {
+    "message": "Brak"
+  },
+  "database_none": {
+    "message": "Brak"
   }
 }

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "Введите ключевое слово для поиска базы данных"
+  },
+  "save_path_none": {
+    "message": "Нет"
+  },
+  "database_none": {
+    "message": "Нет"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -113,6 +113,9 @@
   "template_restore_default": {
     "message": "恢复默认"
   },
+  "template_restore_default": {
+    "message": "恢复默认"
+  },
   "database_label": {
     "message": "添加到数据库"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -109,5 +109,11 @@
   },
   "database_search_placeholder": {
     "message": "输入关键字搜索数据库"
+  },
+  "save_path_none": {
+    "message": "无"
+  },
+  "database_none": {
+    "message": "无"
   }
 }

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -110,6 +110,9 @@
   "template_restore_default": {
     "message": "恢复默认"
   },
+  "template_restore_default": {
+    "message": "恢复默认"
+  },
   "database_label": {
     "message": "添加到数据库"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -107,6 +107,9 @@
   "template_restore_default": {
     "message": "恢复默认"
   },
+  "template_restore_default": {
+    "message": "恢复默认"
+  },
   "database_label": {
     "message": "添加到数据库"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -103,7 +103,10 @@
   },
   "template_help": {
     "message": "可用变量：<br>${title} - 页面标题<br>${url} - 页面URL<br>${siteName} - 网站名称<br>${date} - 当前日期 (yyyy-MM-dd)<br>${time} - 当前时间 (HH:mm)<br>${tags} - 标签<br>${excerpt} - 页面摘要<br>${content} - 页面内容"
-  },  
+  },
+  "template_restore_default": {
+    "message": "恢复默认"
+  },
   "database_label": {
     "message": "添加到数据库"
   },

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -110,5 +110,11 @@
   },
   "database_search_placeholder": {
     "message": "輸入關鍵字搜尋資料庫"
+  },
+  "save_path_none": {
+    "message": "無"
+  },
+  "database_none": {
+    "message": "無"
   }
 }

--- a/background.js
+++ b/background.js
@@ -244,14 +244,23 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
                         // 添加到数据库
                         if (requestData.selectedDatabaseID) {
                             const docId = response.data;
-                            const dbInput = {
-                                avID: requestData.selectedDatabaseID,
-                                srcs: [{
-                                    id: docId,
-                                    isDetached: false,
-                                }]
-                            };
-                            setTimeout(() => {
+
+                            // 先刷新 SQL 数据库
+                            fetch(requestData.api + '/api/sqlite/flushTransaction', {
+                                method: 'POST',
+                                headers: {
+                                    'Authorization': 'Token ' + requestData.token,
+                                },
+                                body: JSON.stringify({}),
+                            }).then(() => {
+                                // 刷新完成后再添加到数据库
+                                const dbInput = {
+                                    avID: requestData.selectedDatabaseID,
+                                    srcs: [{
+                                        id: docId,
+                                        isDetached: false,
+                                    }]
+                                };
                                 fetch(requestData.api + '/api/av/addAttributeViewBlocks', {
                                     method: 'POST',
                                     headers: {
@@ -259,8 +268,7 @@ chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
                                     },
                                     body: JSON.stringify(dbInput),
                                 })
-                            }, 1000); // 延迟 1 秒, 否则无法添加到数据库成功
-
+                            });
                         }
                         chrome.tabs.sendMessage(requestData.tabId, {
                             'func': 'tipKey',

--- a/options.html
+++ b/options.html
@@ -670,6 +670,7 @@
                 <!-- 这里将由JS填充模板变量的帮助信息 -->
             </div>
             <div class="template-buttons">
+                <button id="restoreTemplate" class="b3-button" style="background-color: #e0e0e0; color: #333; width: auto;" data-i18n="template_restore_default">Restore default</button>
                 <button id="cancelTemplate" class="b3-button"
                     style="background-color: #e0e0e0; color: #333; width: auto;"
                     data-i18n="template_cancel">Cancel</button>

--- a/options.html
+++ b/options.html
@@ -458,6 +458,92 @@
             cursor: pointer;
             color: var(--b3-theme-on-surface);
         }
+
+        /* 自定义下拉菜单样式 */
+        .custom-dropdown {
+            position: relative;
+            width: 100%;
+        }
+
+        .dropdown-display {
+            border: 0;
+            border-radius: var(--b3-border-radius);
+            padding: 4px 26px 4px 8px;
+            box-sizing: border-box;
+            line-height: 20px;
+            color: var(--b3-theme-on-background);
+            transition: box-shadow 120ms 0ms cubic-bezier(0, 0, 0.2, 1), background-color .2s cubic-bezier(0, 0, .2, 1) 0ms;
+            height: 28px;
+            font-size: 14px;
+            box-shadow: inset 0 0 0 .6px var(--b3-theme-on-surface);
+            background: var(--b3-select-background);
+            cursor: pointer;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        .dropdown-display:hover {
+            box-shadow: inset 0 0 0 .6px var(--b3-theme-on-background);
+            background-color: var(--b3-theme-surface);
+        }
+
+        .dropdown-display:focus {
+            outline: none;
+            box-shadow: inset 0 0 0 1px var(--b3-theme-primary), 0 0 0 3px var(--b3-theme-primary-lightest);
+        }
+
+        .dropdown-menu {
+            display: none;
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
+            background-color: var(--b3-theme-background);
+            border: 1px solid var(--b3-border-color);
+            border-radius: var(--b3-border-radius);
+            box-shadow: var(--b3-dialog-shadow);
+            z-index: 1000;
+            max-height: 200px;
+            overflow-y: auto;
+        }
+
+        .dropdown-menu.open {
+            display: block;
+        }
+
+        .dropdown-input {
+            width: 100%;
+            padding: 8px;
+            box-sizing: border-box;
+            border: none;
+            border-bottom: 1px solid var(--b3-border-color);
+            outline: none;
+            font-size: 14px;
+        }
+
+        .dropdown-options {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            max-height: 150px;
+            overflow-y: auto;
+        }
+
+        .dropdown-options li {
+            padding: 8px;
+            cursor: pointer;
+            color: var(--b3-theme-on-background);
+        }
+
+        .dropdown-options li:hover {
+            background-color: var(--b3-list-hover);
+        }
+
+        .dropdown-options li.selected {
+            background-color: var(--b3-theme-primary-lightest);
+            color: var(--b3-theme-primary);
+        }
     </style>
 </head>
 
@@ -482,20 +568,28 @@
         </div>
         <div class="fn__hr"></div>
         <div class="b3-label" data-i18n="save_path">Save path</div>
-        <input class="b3-text-field" id="searchDoc" data-i18n="save_path_placeholder"
-            placeholder="Enter a keyword and press Enter to search" />
-        <div class="fn__hr"></div>
-        <select class="b3-select" id="parentDoc"></select>
+        <div class="custom-dropdown" id="savePathDropdown">
+            <div class="dropdown-display" id="savePathDisplay" data-i18n="save_path_none">None</div>
+            <div class="dropdown-menu" id="savePathMenu">
+                <input type="text" class="dropdown-input" id="savePathInput" data-i18n="save_path_placeholder"
+                    placeholder="Enter a keyword to search" />
+                <ul class="dropdown-options" id="savePathOptions"></ul>
+            </div>
+        </div>
         <div class="fn__hr"></div>
         <div class="b3-label" data-i18n="tags">Tags</div>
         <input class="b3-text-field" id="tags" data-i18n="tags_placeholder"
             placeholder="Use commas to separate multiple tags" />
         <div class="fn__hr"></div>
         <div class="b3-label" data-i18n="database_label">Database</div>
-        <input class="b3-text-field" id="searchDatabase" data-i18n="database_search_placeholder"
-            placeholder="Input keyword to search database" />
-        <div class="fn__hr"></div>
-        <select class="b3-select" id="databaseSelect"></select>
+        <div class="custom-dropdown" id="databaseDropdown">
+            <div class="dropdown-display" id="databaseDisplay" data-i18n="database_none">无</div>
+            <div class="dropdown-menu" id="databaseMenu">
+                <input type="text" class="dropdown-input" id="databaseInput" data-i18n="database_search_placeholder"
+                    placeholder="Enter a keyword to search database" />
+                <ul class="dropdown-options" id="databaseOptions"></ul>
+            </div>
+        </div>
         <div class="fn__hr"></div>
         <div class="fn__hr"></div>
         <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
@@ -507,7 +601,8 @@
             <input class="b3-switch" id="exp" type="checkbox">
         </label>
         <div id="expGroup" style="display: none;">
-            <div class="b3-label" style="font-size: 14px; color: red;" data-i18n="exp_tips">*: Experimental features may be unstable. If there is a problem with clipping, consider switching it.</div>
+            <div class="b3-label" style="font-size: 14px; color: red;" data-i18n="exp_tips">*: Experimental features may
+                be unstable. If there is a problem with clipping, consider switching it.</div>
             <label style="display: flex;align-items: center;padding: 0 8px 16px 0;">
                 <div style="flex: 1" data-i18n="exp_span">Detect span text newlines*</div>
                 <input class="b3-switch" id="expSpan" type="checkbox">

--- a/popup.js
+++ b/popup.js
@@ -1,3 +1,17 @@
+// 默认剪藏模板（用于首次加载与恢复默认）
+function getDefaultTemplate() {
+    return '---\n' +
+        '\n' +
+        '- ${title}${siteName ? " - " + siteName : ""}\n' +
+        '- [${urlDecoded}](${url}) \n' +
+        '${excerpt ? "- " + excerpt : ""}\n' +
+        '- ${date} ${time}\n' +
+        '\n' +
+        '---\n' +
+        '\n' +
+        '${content}';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const ipElement = document.getElementById('ip')
     const tokenElement = document.getElementById('token')
@@ -137,6 +151,15 @@ document.addEventListener('DOMContentLoaded', () => {
             // 打开模板配置弹窗
             const templateModal = document.getElementById('templateModal')
             if (templateModal) {
+                // 打开时预填充当前模板（无则回退默认）
+                const templateTextArea = document.getElementById('templateText')
+                if (templateTextArea) {
+                    chrome.storage.sync.get({
+                        clipTemplate: getDefaultTemplate(),
+                    }, (t) => {
+                        templateTextArea.value = t.clipTemplate || getDefaultTemplate()
+                    })
+                }
                 templateModal.style.display = 'block'
             }
         })
@@ -162,6 +185,23 @@ document.addEventListener('DOMContentLoaded', () => {
                             templateSavedMsg.style.display = 'none'
                         }, 2000)
                     }
+                }
+            })
+        })
+    }
+
+    // 添加模板恢复默认按钮事件
+    const restoreTemplateBtn = document.getElementById('restoreTemplate')
+    if (restoreTemplateBtn) {
+        restoreTemplateBtn.addEventListener('click', () => {
+            const templateTextArea = document.getElementById('templateText')
+            const def = getDefaultTemplate()
+            if (templateTextArea) templateTextArea.value = def
+            chrome.storage.sync.set({ clipTemplate: def }, () => {
+                const templateSavedMsg = document.getElementById('templateSavedMsg')
+                if (templateSavedMsg) {
+                    templateSavedMsg.style.display = 'block'
+                    setTimeout(() => { templateSavedMsg.style.display = 'none' }, 2000)
                 }
             })
         })
@@ -293,16 +333,7 @@ document.addEventListener('DOMContentLoaded', () => {
         expRemoveImgLink: false,
         expListDocTree: false,
         expSvgToImg: false,
-        clipTemplate: '---\n' +
-            '\n' +
-            '- ${title}${siteName ? " - " + siteName : ""}\n' +
-            '- [${urlDecoded}](${url}) \n' +
-            '${excerpt ? "- " + excerpt : ""}\n' +
-            '- ${date} ${time}\n' +
-            '\n' +
-            '---\n' +
-            '\n' +
-            '${content}',
+        clipTemplate: getDefaultTemplate(),
     }, async function (items) {
         siyuanLoadLanguageFile(items.langCode, (data) => {
             siyuanTranslateDOM(data); // 在这里使用加载的i18n数据

--- a/popup.js
+++ b/popup.js
@@ -382,7 +382,7 @@ const updateSearch = () => {
 
         let optionsHTML = ''
         if (!savePathInput.value.trim()) {
-            optionsHTML = '<li data-notebook="" data-parent="">无</li>' // Default empty option when no search term
+            optionsHTML = `<li data-notebook="" data-parent="">${chrome.i18n.getMessage("save_path_none")}</li>`
         }
         let selectedHPath = ''
         response.data.forEach(doc => {
@@ -440,11 +440,15 @@ const updateDatabaseSearch = () => {
 
         let optionsHTML = ''
         if (!databaseInput.value.trim()) {
-            optionsHTML = '<li data-id="">无</li>' // Default empty option when no search term
+            optionsHTML = `<li data-id="">${chrome.i18n.getMessage("database_none")}</li>`
         }
         let selectedName = '-- Select Database --'
         if (response.data && response.data.results) {
             response.data.results.forEach(db => {
+                if (!db.avName) {
+                    return;
+                }
+
                 let selectedClass = ""
                 if (databaseDisplay.dataset.selectedId === db.avID) {
                     selectedClass = "selected";

--- a/popup.js
+++ b/popup.js
@@ -349,44 +349,67 @@ document.addEventListener('DOMContentLoaded', () => {
     })
 })
 
-const updateSearch = () => {
+const updateSearch = async () => {
     const ipElement = document.getElementById('ip')
     const tokenElement = document.getElementById('token')
     const savePathInput = document.getElementById('savePathInput')
     const savePathOptions = document.getElementById('savePathOptions')
     const savePathDisplay = document.getElementById('savePathDisplay')
 
-    fetch(ipElement.value + '/api/filetree/searchDocs', {
-        method: 'POST',
-        redirect: "manual",
-        headers: {
-            'Authorization': 'Token ' + tokenElement.value,
-        },
-        body: JSON.stringify({
-            "k": savePathInput.value,
-            "flashcard": false
+    // Validate token
+    if (!tokenElement.value || tokenElement.value.trim() === '') {
+        const msg = chrome.i18n.getMessage('tip_token_miss') || 'Please configure the API token before clipping content'
+        document.getElementById('log').innerHTML = msg
+        return
+    }
+
+    // Normalize base URL
+    let base = (ipElement.value || '').trim()
+    if (!base) base = 'http://127.0.0.1:6806'
+    if (!/^https?:\/\//i.test(base)) base = 'http://' + base
+    while (base.endsWith('/')) base = base.slice(0, -1)
+
+    try {
+        const response = await fetch(base + '/api/filetree/searchDocs', {
+            method: 'POST',
+            headers: {
+                'Authorization': 'Token ' + tokenElement.value,
+                'Content-Type': 'application/json; charset=UTF-8',
+            },
+            body: JSON.stringify({
+                k: savePathInput.value || '',
+                flashcard: false,
+            })
         })
-    }).then((response) => {
+        if (response.status === 401 || response.status === 403) {
+            const msg = chrome.i18n.getMessage('tip_token_invalid') || 'Invalid API token'
+            document.getElementById('log').innerHTML = msg
+            return
+        }
         if (response.status !== 200) {
-            document.getElementById('log').innerHTML = "Authentication failed, please check API token"
+            const msg = chrome.i18n.getMessage('tip_siyuan_kernel_unavailable') || 'Please start SiYuan and ensure network connectivity before trying again'
+            document.getElementById('log').innerHTML = msg
             return
         }
-
-        document.getElementById('log').innerHTML = ""
-        return response.json()
-    }).then((response) => {
-        if (0 !== response.code) {
-            document.getElementById('log').innerHTML = "Search docs failed"
+        document.getElementById('log').innerHTML = ''
+        let data
+        try {
+            data = await response.json()
+        } catch (e) {
+            const msg = chrome.i18n.getMessage('tip_siyuan_kernel_unavailable') || 'Please start SiYuan and ensure network connectivity before trying again'
+            document.getElementById('log').innerHTML = msg
             return
         }
-
+        if (!data || data.code !== 0 || !Array.isArray(data.data)) {
+            return
+        }
         let optionsHTML = ''
         if (!savePathInput.value.trim()) {
             optionsHTML = `<li data-notebook="" data-parent="">${chrome.i18n.getMessage("save_path_none")}</li>`
         }
         let selectedHPath = ''
-        response.data.forEach(doc => {
-            const parentDoc = doc.path.substring(doc.path.toString().lastIndexOf('/') + 1).replace(".sy", '')
+        data.data.forEach(doc => {
+            const parentDoc = String(doc.path).substring(String(doc.path).lastIndexOf('/') + 1).replace('.sy', '')
             let selectedClass = ""
             if (savePathDisplay.dataset.notebook === doc.box && savePathDisplay.dataset.parent === parentDoc &&
                 savePathDisplay.dataset.parenthpath === doc.hPath) {
@@ -401,7 +424,10 @@ const updateSearch = () => {
         if (selectedHPath) {
             savePathDisplay.textContent = selectedHPath
         }
-    })
+    } catch (e) {
+        const msg = chrome.i18n.getMessage('tip_siyuan_kernel_unavailable') || 'Please start SiYuan and ensure network connectivity before trying again'
+        document.getElementById('log').innerHTML = msg
+    }
 }
 
 const updateDatabaseSearch = () => {
@@ -470,7 +496,9 @@ const updateDatabaseSearch = () => {
 }
 
 const escapeHtml = (unsafe) => {
-    return unsafe
+    if (unsafe == null) return ''
+    const s = String(unsafe)
+    return s
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
@@ -516,10 +544,30 @@ const siyuanGetReadability = async (tabId) => {
 let siyuanLangData = null;
 let siyuanLangCode = null;
 
+function siyuanResolveLocale(lang) {
+    try {
+        const available = ['ar','de','en','es','fr','he','it','ja','pl','ru','zh_CN','zh_TW'];
+        if (!lang) return 'en';
+        let code = String(lang).replace('-', '_');
+        if (code.toLowerCase().startsWith('zh')) {
+            const lower = code.toLowerCase();
+            if (lower.includes('tw') || lower.includes('hk') || lower.includes('mo') || lower.includes('hant')) {
+                return 'zh_TW';
+            }
+            return 'zh_CN';
+        }
+        if (available.includes(code)) return code;
+        const base = code.split('_')[0];
+        if (available.includes(base)) return base;
+        return 'en';
+    } catch (e) {
+        return 'en';
+    }
+}
+
 function siyuanGetDefaultLangCode() {
-    const langCode = navigator.language || navigator.userLanguage || chrome.runtime.getManifest().default_locale;
-    const normalizedLangCode = langCode.replace('-', '_');
-    return normalizedLangCode;
+    const raw = navigator.language || navigator.userLanguage || chrome.runtime.getManifest().default_locale || 'en';
+    return siyuanResolveLocale(raw);
 }
 
 // 合并当前语言和英语（en）翻译的函数
@@ -532,15 +580,14 @@ async function siyuanMergeTranslations(translations, langCode) {
 
     // 如果当前语言不是英语，则加载英语翻译文件
     if (langCode !== defaultLangCode) {
-        const enTranslationFile = chrome.runtime.getURL(`_locales/${langCode}/messages.json`);
+        const enTranslationFile = chrome.runtime.getURL(`_locales/${defaultLangCode}/messages.json`);
         try {
-            // 异步加载英语翻译文件
             const response = await fetch(enTranslationFile);
             if (!response.ok) {
                 throw new Error('Network response was not ok');
             }
-            const enData = await response.json(); // 解析JSON
-            defaultTranslations = enData; // 保存英语翻译数据
+            const enData = await response.json();
+            defaultTranslations = enData;
         } catch (err) {
             console.error("Failed to load English translation:", err);
         }
@@ -552,59 +599,53 @@ async function siyuanMergeTranslations(translations, langCode) {
 }
 
 async function siyuanLoadLanguageFile(langCode, callback) {
-    // 检查是否已经加载过数据
-    if (siyuanLangData && siyuanLangCode === langCode) {
-        // 如果已经加载，直接调用回调并传递数据
+    const normalized = (typeof siyuanResolveLocale === 'function') ? siyuanResolveLocale(langCode) : (langCode || 'en');
+
+    if (siyuanLangData && siyuanLangCode === normalized) {
         callback(siyuanLangData);
         return;
     }
 
-    // 先加载当前语言的翻译文件
-    try {
-        const translationFile = chrome.runtime.getURL(`_locales/${langCode}/messages.json`);
-        const response = await fetch(translationFile);
-        if (!response.ok) {
-            throw new Error('Network response was not ok');
+    const tryLoad = async (code) => {
+        try {
+            const translationFile = chrome.runtime.getURL(`_locales/${code}/messages.json`);
+            const response = await fetch(translationFile);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return await response.json();
+        } catch (e) {
+            return null;
         }
-        const data = await response.json(); // 解析JSON
+    };
 
-        // 加载成功，检查并补充缺失的翻译
-        // 先把加载的翻译数据保存在全局变量中
-        const mergedData = await siyuanMergeTranslations(data, langCode); // 等待合并翻译
-        siyuanLangData = mergedData;
-        siyuanLangCode = langCode;
+    let data = await tryLoad(normalized);
+    if (!data) data = await tryLoad('en');
+    if (!data) data = {};
 
-        // 调用回调并传递数据
-        callback(mergedData);
-
-    } catch (error) {
-        console.error('There was a problem with the fetch operation:', error);
-    }
+    const mergedData = await siyuanMergeTranslations(data, normalized);
+    siyuanLangData = mergedData;
+    siyuanLangCode = normalized;
+    callback(mergedData);
 }
 
 function siyuanTranslateDOM(translations) {
+    const t = translations || {};
     const elements = document.querySelectorAll('[data-i18n]');
     elements.forEach(element => {
         const key = element.getAttribute('data-i18n');
-        if (!translations[key] || !translations[key].message) {
-            console.warn(`siyuanTranslateDOM Missing translation for key: ${key}`);
+        const msg = t[key] && t[key].message ? t[key].message : null;
+        if (!msg) {
             return;
         }
-
-        const translation = translations[key].message;
-        if (element.placeholder !== undefined) {
-            // 翻译 placeholder 属性
-            element.placeholder = translation;
+        if ('placeholder' in element) {
+            element.placeholder = msg;
         } else {
-            // 翻译 textContent
-            element.textContent = translation;
+            element.textContent = msg;
         }
     });
 
-    // 确保模板帮助文本也被更新
     const templateHelp = document.getElementById('templateHelp');
-    if (templateHelp && translations.template_help) {
-        templateHelp.innerHTML = translations.template_help.message;
+    if (templateHelp && t.template_help && t.template_help.message) {
+        templateHelp.innerHTML = t.template_help.message;
     }
 }
 


### PR DESCRIPTION
1. "Clipping template" setting showed an empty box by default. It now shows the default clipping template which can be modified by the user. The variables available to the clipper are listed below the box.

2. "Clipping template" was not possible to restore to default. If user entered a new template text, then removed it (revert to empty box), the default template was not restored. Now there is a button for restoring the original template.

3. error log messages: while testing this change, a timer was sending a message but failing. I have added a safer way for those messages to send so the error log remains clear

4. this change is significant enough to suggest increasing the version number,  but I am not sure if you want to do that.

Thank you!

---

（谷歌翻译）

1. “剪辑模板”设置默认显示一个空框。现在显示默认的剪辑模板，用户可以修改。剪辑器可用的变量列在框下方。

2. “剪辑模板”无法恢复为默认模板。如果用户输入了新的模板文本，然后将其删除（恢复为空框），则无法恢复默认模板。现在有一个按钮可以恢复原始模板。

3. 错误日志消息：在测试此更改时，一个计时器正在发送消息，但失败了。我添加了一种更安全的发送这些消息的方式，以便错误日志保持清晰。

4. 此更改非常重要，建议提高版本号，但我不确定您是否愿意这样做。

谢谢！